### PR TITLE
优化 exec 方法查找逻辑，排除 bridge 和 synthetic 方法

### DIFF
--- a/ddd-core/src/main/java/org/netcorepal/cap4j/ddd/archinfo/ArchInfoManager.java
+++ b/ddd-core/src/main/java/org/netcorepal/cap4j/ddd/archinfo/ArchInfoManager.java
@@ -367,12 +367,12 @@ public class ArchInfoManager {
     }
 
     protected Type resolveRequestClass(Class<?> requestHandlerCls) {
-        Method method = ClassUtils.findMethod(requestHandlerCls, "exec", m -> m.getParameterCount() == 1);
+        Method method = ClassUtils.findMethod(requestHandlerCls, "exec", m -> m.getParameterCount() == 1 && !m.isBridge() && !m.isSynthetic());
         return method.getGenericParameterTypes()[0];
     }
 
     protected Type resolveResponseClass(Class<?> requestHandlerCls) {
-        Method method = ClassUtils.findMethod(requestHandlerCls, "exec", m -> m.getParameterCount() == 1);
+        Method method = ClassUtils.findMethod(requestHandlerCls, "exec", m -> m.getParameterCount() == 1 && !m.isBridge() && !m.isSynthetic());
         return method.getGenericReturnType();
     }
 


### PR DESCRIPTION
exce 方法由于返回值是泛型的， 可能会获取到编译生成的桥方法, 导致获取的返回值为 Object